### PR TITLE
Update model to read in GRIB datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This requires conda to be installed, and should create a virtual environment wit
 
 If you prefer to do a clean install of the required packages, the following commands will create a virtual environment:
 
-    conda create -n tc_risk basemap cftime xarray numpy matplotlib cartopy python jupyter scipy netCDF4 dask
+    conda create -n tc_risk basemap cftime xarray numpy matplotlib cartopy python jupyter scipy netCDF4 dask eccodes cfgrib
     pip install global-land-mask cdsapi
 
 Note, not all Python packages are fully supported on Apple Silicon architecture yet.

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - xarray
   - cftime
   - python
-  - eccodes
-  - cfgrib
+  - -c conda-forge eccodes
+  - -c conda-forge cfgrib
   - pip:
     - cdsapi
     - global-land-mask

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,8 @@ dependencies:
   - xarray
   - cftime
   - python
+  - eccodes
+  - cfgrib
   - pip:
     - cdsapi
     - global-land-mask

--- a/intensity/coupled_fast.py
+++ b/intensity/coupled_fast.py
@@ -175,7 +175,8 @@ class Coupled_FAST(bam_track.BetaAdvectionTrack):
         gamma = self._calc_gamma(alpha)
         beta = self._calc_beta()
 
-        numer = 2 * self.h_bl / self.Cd * dvdt + (y[2] ** 2)
+        Cd = self._get_current_Cd(clon, clat)
+        numer = 2 * self.h_bl / Cd * dvdt + (y[2] ** 2)
         denom = alpha * beta * (v_pot ** 2) + gamma * (y[2] ** 2)
         return(np.maximum(np.minimum(np.cbrt(numer / denom), 1), 0))
 

--- a/intensity/geo.py
+++ b/intensity/geo.py
@@ -32,3 +32,26 @@ def read_land(basin):
     lon_b, lat_b, land_b = basin.transform_global_field(lon, lat, land)
     f_land = interp2d(lon_b, lat_b, land_b.T, kx=1, ky=1)
     return(f_land)
+
+# Reads in drag coefficient file.
+# Returns a normalized drag coefficient, which represents the multiplicative
+# value of the drag coefficient as compared to the neutral over-ocean Cd.
+def read_drag(basin):
+    fdir = namelist.src_directory
+    fn = '%s/intensity/data/Cd.nc' % fdir
+    ds = xr.open_dataset(fn)
+    lon = ds['longitude'].data
+    lat = ds['latitude'].data
+    Cd = ds['Cd'].data
+    ds.close()
+
+    # Converts from a 10m altitude drag coefficient to a
+    # drag coefficient more appropriate to the gradient wind, and
+    # normalizes with respect to over-ocean Cd.
+    Cd_gradient = Cd / (1 + 50.0 * Cd)
+    Cd_norm = Cd_gradient / np.min(Cd_gradient)
+    Cd = namelist.Cd * Cd_norm
+
+    lon_b, lat_b, Cd_b = basin.transform_global_field(lon, lat, Cd)
+    f_Cd = interp2d(lon_b, lat_b, Cd_b.T, kx=1, ky=1)
+    return(f_Cd)

--- a/intensity/geo.py
+++ b/intensity/geo.py
@@ -48,7 +48,7 @@ def read_drag(basin):
     # Converts from a 10m altitude drag coefficient to a
     # drag coefficient more appropriate to the gradient wind, and
     # normalizes with respect to over-ocean Cd.
-    Cd_gradient = Cd / (1 + 50.0 * Cd)
+    Cd_gradient = Cd / (1 + 250.0 * Cd)
     Cd_norm = Cd_gradient / np.min(Cd_gradient)
     Cd = namelist.Cd * Cd_norm
 

--- a/namelist.py
+++ b/namelist.py
@@ -13,8 +13,11 @@ exp_name = 'test'
 # For now, we support either 'GCM' or 'ERA5'. Different file types and variable
 # names can be added by modifying the "input.py" file and adding the appropriate
 # variable key words in the structure var_keys.
+# file_type is the file type of the input files, and
+# can be either 'netcdf' or 'grib'
 dataset_type = 'ERA5' #'GCM'
 exp_prefix = 'era5' #GFDL-CM4_ssp585_r1i1p1f1'
+file_type = 'grib'
 
 # Variable naming based on dataset_type.
 # 'sst' is sea-surface temperature (monthly-averaged)
@@ -25,7 +28,7 @@ exp_prefix = 'era5' #GFDL-CM4_ssp585_r1i1p1f1'
 # 'v' is meridional wind (daily)
 var_keys = {'ERA5': {'sst': 'sst', 'mslp': 'sp', 'temp': 't',
                      'sp_hum': 'q', 'u': 'u', 'v': 'v',
-                     'lvl': 'level', 'lon': 'longitude', 'lat': 'latitude'},
+                     'lvl': 'isobaricInhPa', 'lon': 'longitude', 'lat': 'latitude'},
             'GCM': {'sst': 'tos', 'mslp': 'psl', 'temp': 'ta',
                     'sp_hum': 'hus', 'u': 'ua', 'v': 'va',
                     'lvl': 'plev', 'lon': 'lon', 'lat': 'lat'}}

--- a/scripts/download_era5.py
+++ b/scripts/download_era5.py
@@ -25,7 +25,7 @@ def request_file(fn, req_type, req):
     if not os.path.isfile(fn):
         try:
             print('Requesting %s...' % fn)
-            c.retrieve(req_type, req, fn)
+            c.retrieve(req_type, req, fn).download()
             print('Downloaded %s...' % fn)
         except:
             print("Error downloading the data...")
@@ -37,30 +37,30 @@ def f_request(year):
     fn_dir = '%s/%d' % (fn_base, year)
     if not os.path.exists(fn_dir):
         os.makedirs(fn_dir)
-    
-    sst_fn = '%s/era5_sst_monthly_%d.nc' % (fn_dir, year)
-    sp_fn = '%s/era5_sp_monthly_%d.nc' % (fn_dir, year)
-    q_fn = '%s/era5_q_monthly_%d.nc' % (fn_dir, year)
-    t_fn = '%s/era5_t_monthly_%d.nc' % (fn_dir, year)
-    u_fn = '%s/era5_u_daily_%d.nc' % (fn_dir, year)
-    v_fn = '%s/era5_v_daily_%d.nc' % (fn_dir, year)
+
+    sst_fn = '%s/era5_sst_monthly_%d.grib' % (fn_dir, year)
+    sp_fn = '%s/era5_sp_monthly_%d.grib' % (fn_dir, year)
+    q_fn = '%s/era5_q_monthly_%d.grib' % (fn_dir, year)
+    t_fn = '%s/era5_t_monthly_%d.grib' % (fn_dir, year)
+    u_fn = '%s/era5_u_daily_%d.grib' % (fn_dir, year)
+    v_fn = '%s/era5_v_daily_%d.grib' % (fn_dir, year)
 
     req_sst = {
-        'format': 'netcdf',
-        'product_type': 'monthly_averaged_reanalysis',
-        'variable': 'sea_surface_temperature',
-        'year': str(year),
+        'data_format': 'grib',
+        'product_type': ['monthly_averaged_reanalysis'],
+        'variable': ['sea_surface_temperature'],
+        'year': [str(year)],
         'month': ['01', '02', '03',
                   '04', '05', '06',
                   '07', '08', '09',
                   '10', '11', '12',
               ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': '00:00'
     }
 
     req_sp = {
-        'format': 'netcdf',
+        'data_format': 'grib',
         'product_type': 'monthly_averaged_reanalysis',
         'variable': 'surface_pressure',
         'year': str(year),
@@ -69,12 +69,12 @@ def f_request(year):
                   '07', '08', '09',
                   '10', '11', '12',
               ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': '00:00'
     }
 
     req_q = {
-        'format': 'netcdf',
+        'data_format': 'grib',
         'product_type': 'monthly_averaged_reanalysis',
         'variable': 'specific_humidity',
         'pressure_level': [ '70', '100', '125', '150', '175', '200',
@@ -89,12 +89,12 @@ def f_request(year):
                   '07', '08', '09',
                   '10', '11', '12',
               ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': '00:00',
     }
 
     req_t = {
-        'format': 'netcdf',
+        'data_format': 'grib',
         'product_type': 'monthly_averaged_reanalysis',
         'variable': 'temperature',
         'pressure_level': [ '70', '100', '125', '150', '175', '200',
@@ -109,13 +109,13 @@ def f_request(year):
                   '07', '08', '09',
                   '10', '11', '12',
               ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': '00:00',
     }
 
     req_u = {
         'product_type': 'reanalysis',
-        'format': 'netcdf',
+        'data_format': 'grib',
         'variable': 'u_component_of_wind',
         'pressure_level': ['250', '850'],
         'year': str(year),
@@ -131,13 +131,13 @@ def f_request(year):
                 '25', '26', '27', '28', '29', '30',
                 '31',
             ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': ['00:00', '12:00'],
     }
 
     req_v = {
         'product_type': 'reanalysis',
-        'format': 'netcdf',
+        'data_format': 'grib',
         'variable': 'v_component_of_wind',
         'pressure_level': ['250', '850'],
         'year': str(year),
@@ -153,7 +153,7 @@ def f_request(year):
                 '25', '26', '27', '28', '29', '30',
                 '31',
             ],
-        'grid': '1.0/1.0',
+        'grid': '2.0/2.0',
         'time': ['00:00', '12:00'],
     }
 

--- a/scripts/download_era5.py
+++ b/scripts/download_era5.py
@@ -23,13 +23,9 @@ os.makedirs(fn_base, exist_ok = True)
 def request_file(fn, req_type, req):
     c = cdsapi.Client()
     if not os.path.isfile(fn):
-        try:
-            print('Requesting %s...' % fn)
-            c.retrieve(req_type, req, fn).download()
-            print('Downloaded %s...' % fn)
-        except:
-            print("Error downloading the data...")
-            pass
+        print('Requesting %s...' % fn)
+        c.retrieve(req_type, req, fn)
+        print('Downloaded %s...' % fn)
     else:
         print('Found file %s...' % fn)
 

--- a/thermo/calc_thermo.py
+++ b/thermo/calc_thermo.py
@@ -112,6 +112,6 @@ def gen_thermo():
                                             rh_mid = (['time', 'lat', 'lon'], rh_mid)),
                            coords = dict(lon = ("lon", ds[input.get_lon_key()].data),
                                          lat = ("lat", ds[input.get_lat_key()].data),
-                                         time = ("time", ds_times)))
+                                         time = ("time", ds_times.astype('datetime64[ns]'))))
     ds_thermo.to_netcdf(get_fn_thermo())
     print('Saved %s' % get_fn_thermo())

--- a/thermo/calc_thermo.py
+++ b/thermo/calc_thermo.py
@@ -11,6 +11,7 @@ import namelist
 import numpy as np
 import xarray as xr
 
+from dask.distributed import LocalCluster, Client
 from util import input, mat
 from thermo import thermo
 
@@ -92,11 +93,16 @@ def gen_thermo():
 
     n_chunks = namelist.n_procs
     chunks = np.array_split(ds_times, np.minimum(n_chunks, np.floor(len(ds_times) / 2)))
+
+    cl_args = {'n_workers': namelist.n_procs,
+               'processes': True,
+               'threads_per_worker': 1}
     lazy_results = []
-    for i in range(len(chunks)):
-        lazy_result = dask.delayed(compute_thermo)(chunks[i][0], chunks[i][-1])
-        lazy_results.append(lazy_result)
-    out = dask.compute(*lazy_results, scheduler = 'processes', num_workers = n_chunks)
+    with LocalCluster(**cl_args) as cluster, Client(cluster) as client:
+        for i in range(n_chunks):
+            lazy_result = dask.delayed(compute_thermo)(chunks[i][0], chunks[i][-1])
+            lazy_results.append(lazy_result)
+        out = dask.compute(*lazy_results, scheduler = 'processes', num_workers = n_chunks)
 
     # Clean up and process output.
     # Ensure monthly timestamps have middle-of-the-month days.

--- a/track/bam_track.py
+++ b/track/bam_track.py
@@ -58,7 +58,7 @@ class BetaAdvectionTrack:
         self.v_beta = namelist.v_beta           # meridional beta drift speed
         self.nLvl = len(namelist.steering_levels)
         self.nWLvl = self.nLvl * 2
-        self.dt_start = dt_start
+        self.dt_start = dt_start.astype('datetime64[ns]')
         self.basin = basin
         self.var_names = env_wind.wind_mean_vector_names()
         self.u_Mean_idxs = np.zeros(self.nLvl).astype(int)

--- a/track/env_wind.py
+++ b/track/env_wind.py
@@ -155,7 +155,7 @@ def wnd_stat_wrapper(args):
                           dims = ['time', 'stat', 'lat', 'lon'],
                           coords = dict(lon = ("lon", ds_ua[input.get_lon_key()].data),
                                         lat = ("lat", ds_ua[input.get_lat_key()].data),
-                                        time = ("time", input.convert_from_datetime(ds_ua, t_months))))
+                                        time = ("time", input.convert_from_datetime(ds_ua, t_months).astype('datetime64[ns]'))))
     ds_wnd = da_wnd.to_dataset(name='wnd_stats')
     fn_ds_wnd = '%s/env_wnd_%s_p%d%02d_%d%02d.nc' % (namelist.output_directory, namelist.exp_prefix,
                                                      t_months[0].year, t_months[0].month,

--- a/track/env_wind.py
+++ b/track/env_wind.py
@@ -5,6 +5,7 @@ import os
 import xarray as xr
 
 import namelist
+from dask.distributed import LocalCluster, Client
 from util import input
 
 """
@@ -90,12 +91,16 @@ def gen_wind_mean_cov():
     fns_ua = input._glob_prefix(input.get_u_key())
     fns_va = input._glob_prefix(input.get_v_key())
 
+    cl_args = {'n_workers': namelist.n_procs,
+               'processes': True,
+               'threads_per_worker': 1}
     lazy_results = []
-    for i in range(min(len(fns_ua), len(fns_va))):
-        lazy_result = dask.delayed(wnd_stat_wrapper)((fns_ua[i], fns_va[i]))
-        lazy_results.append(lazy_result)
-    out = dask.compute(*lazy_results)
-    out_fns = [x for x in out if x is not None]
+    with LocalCluster(**cl_args) as cluster, Client(cluster) as client:
+        for i in range(min(len(fns_ua), len(fns_va))):
+            lazy_result = dask.delayed(wnd_stat_wrapper)((fns_ua[i], fns_va[i]))
+            lazy_results.append(lazy_result)
+        out = dask.compute(*lazy_results)
+        out_fns = [x for x in out if x is not None]
 
     # Combine all intermediate files into one dataset, and delete
     ds = input._open_fns(out_fns)

--- a/util/compute.py
+++ b/util/compute.py
@@ -22,6 +22,10 @@ Driver function to compute zonal and meridional wind monthly mean and
 covariances, potential intensity, GPI, and saturation deficit.
 """
 def compute_downscaling_inputs():
+    if namelist.file_type == 'grib':
+        print('Preprocessing .grib files...')
+        input.preprocess_grib()
+    
     print('Computing monthly mean and variance of environmental wind...')
     s = time.time()
     env_wind.gen_wind_mean_cov()
@@ -106,7 +110,7 @@ def run_tracks(year, n_tracks, b):
     ds_wnd = xr.open_dataset(fn_wnd_stat)
     for i in range(12):
         dt_month = datetime.datetime(year, i + 1, 15)
-        ds_dt_month = input.convert_from_datetime(ds_wnd, [dt_month])[0]
+        ds_dt_month = input.convert_from_datetime(ds_wnd, [dt_month])[0].astype('datetime64[ns]')
         vpot_month = np.nan_to_num(vpot.interp(time = ds_dt_month).data, 0)
         rh_mid_month = rh_mid.interp(time = ds_dt_month).data
         chi_month = chi.interp(time = ds_dt_month).data

--- a/util/compute.py
+++ b/util/compute.py
@@ -11,6 +11,7 @@ import xarray as xr
 import time
 
 import namelist
+from dask.distributed import LocalCluster, Client
 from intensity import coupled_fast, ocean
 from thermo import calc_thermo
 from track import env_wind
@@ -224,14 +225,18 @@ def run_downscaling(basin_id):
     yearS = namelist.start_year
     yearE = namelist.end_year
 
-    lazy_results = []; f_args = [];
-    for yr in range(yearS, yearE+1):
-        lazy_result = dask.delayed(run_tracks)(yr, n_tracks, b)
-        f_args.append((yr, n_tracks, b))
-        lazy_results.append(lazy_result)
-
-    s = time.time()
-    out = dask.compute(*lazy_results, scheduler = 'processes', num_workers = n_procs)
+    cl_args = {'n_workers': namelist.n_procs,
+               'processes': True,
+               'threads_per_worker': 1}
+    with LocalCluster(**cl_args) as cluster, Client(cluster) as client:
+        lazy_results = []
+        f_args = []
+        for yr in range(yearS, yearE+1):
+            lazy_result = dask.delayed(run_tracks)(yr, n_tracks, b)
+            f_args.append((yr, n_tracks, b))
+            lazy_results.append(lazy_result)
+        s = time.time()
+        out = dask.compute(*lazy_results)
 
     # Process the output and save as a netCDF file.
     tc_lon = np.concatenate([x[0] for x in out], axis = 0)

--- a/util/compute.py
+++ b/util/compute.py
@@ -276,4 +276,3 @@ def run_downscaling(basin_id):
     fn_trk_out = fn_tracks_duplicates(get_fn_tracks(b))
     ds.to_netcdf(fn_trk_out, mode = 'w')
     print('Saved %s' % fn_trk_out)
-    print(time.time() - s)


### PR DESCRIPTION
Update model to read in GRIB datasets and use nanosecond precision for the time, suppressing warnings on nanosecond precision. This is necessary since there was an update to how netcdfs are served via the CDS platform.

Adds a new option to the namelist:
`file_type`

which can be set to either `netcdf` or `grib` depending on the file type of your data source. This should be backwards compatible with users who have already downloaded the netcdf-compatible data files of ERA5 from the CDS platform, though they will have issues when trying to download more years.

One key change in the namelist is the change of the `lvl` parameter to `isobaricInhPa`, which is the GRIB standard for isobaric pressure levels.