### PR TITLE
include variable drag coefficient

### DIFF
--- a/intensity/coupled_fast.py
+++ b/intensity/coupled_fast.py
@@ -175,7 +175,8 @@ class Coupled_FAST(bam_track.BetaAdvectionTrack):
         gamma = self._calc_gamma(alpha)
         beta = self._calc_beta()
 
-        numer = 2 * self.h_bl / self.Cd * dvdt + (y[2] ** 2)
+        Cd = self._get_current_Cd(clon, clat)
+        numer = 2 * self.h_bl / Cd * dvdt + (y[2] ** 2)
         denom = alpha * beta * (v_pot ** 2) + gamma * (y[2] ** 2)
         return(np.maximum(np.minimum(np.cbrt(numer / denom), 1), 0))
 

--- a/intensity/geo.py
+++ b/intensity/geo.py
@@ -32,3 +32,26 @@ def read_land(basin):
     lon_b, lat_b, land_b = basin.transform_global_field(lon, lat, land)
     f_land = interp2d(lon_b, lat_b, land_b.T, kx=1, ky=1)
     return(f_land)
+
+# Reads in drag coefficient file.
+# Returns a normalized drag coefficient, which represents the multiplicative
+# value of the drag coefficient as compared to the neutral over-ocean Cd.
+def read_drag(basin):
+    fdir = namelist.src_directory
+    fn = '%s/intensity/data/Cd.nc' % fdir
+    ds = xr.open_dataset(fn)
+    lon = ds['longitude'].data
+    lat = ds['latitude'].data
+    Cd = ds['Cd'].data
+    ds.close()
+
+    # Converts from a 10m altitude drag coefficient to a
+    # drag coefficient more appropriate to the gradient wind, and
+    # normalizes with respect to over-ocean Cd.
+    Cd_gradient = Cd / (1 + 50.0 * Cd)
+    Cd_norm = Cd_gradient / np.min(Cd_gradient)
+    Cd = namelist.Cd * Cd_norm
+
+    lon_b, lat_b, Cd_b = basin.transform_global_field(lon, lat, Cd)
+    f_Cd = interp2d(lon_b, lat_b, Cd_b.T, kx=1, ky=1)
+    return(f_Cd)


### PR DESCRIPTION
Adds functionality for variable drag coefficient, which increases the decay rate over land. Fixes a previous issue where storms did not decay quickly enough over land, leading to positive biases in return period calculations for inland locations.